### PR TITLE
Fix Static on negative signals

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -3,29 +3,24 @@
 // Step 1
 int16_t decode_from_table(char input)
 {
-    uint16_t sign = ((0x80 & input) >> 7) ^ 0x1;
-    uint16_t step = 0x0F & input;
-    uint16_t chord = (0x70 & input) >> 4;
+    uint16_t sign = ((0x80 & input) >> 7) ^ 0x01;
+    uint16_t chord = ((0x70 & input) >> 4);
+    uint16_t step = (0x0F & input);
 
-    uint16_t leading_one = 0x01 << (2 + 5 + chord);
-    uint16_t trailing_one = 0x01 << (2 + chord);
+    uint16_t leading_one = 0x0001 << (2 + 5 + chord);
     uint16_t shifted_step = step << (2 + 1 + chord);
     uint16_t shifted_bias = 132;
-    if (chord > 7)
-        printf("uhohhhh");
 
-    int16_t decoded = (int16_t)(shifted_step);
+    int16_t decoded = leading_one + shifted_step - shifted_bias;
 
     // If Neg
     if (sign == NEG)
     {
-        // printf("%d\n", -decoded);
         return -decoded;
     }
     // If Pos
     else
     {
-        // printf("%d\n", decoded);
         return decoded;
     }
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -3,25 +3,29 @@
 // Step 1
 int16_t decode_from_table(char input)
 {
-    uint16_t sign = (0x1 & (input >> 7)) ^ 0x1;
-    uint16_t step = 0xF & input;
-    uint16_t chord = 0x7 & (input >> 4);
+    uint16_t sign = ((0x80 & input) >> 7) ^ 0x1;
+    uint16_t step = 0x0F & input;
+    uint16_t chord = (0x70 & input) >> 4;
 
-    uint16_t leading_one = 0x01 << (2 + 4 + chord);
+    uint16_t leading_one = 0x01 << (2 + 5 + chord);
     uint16_t trailing_one = 0x01 << (2 + chord);
-    uint16_t shifted_chord = step << (2 + 1 + chord);
-    uint16_t shifted_bias = 33 << 2;
+    uint16_t shifted_step = step << (2 + 1 + chord);
+    uint16_t shifted_bias = 132;
+    if (chord > 7)
+        printf("uhohhhh");
 
-    int16_t decoded = (int16_t)(leading_one + shifted_chord + trailing_one - shifted_bias);
+    int16_t decoded = (int16_t)(shifted_step);
 
     // If Neg
     if (sign == NEG)
     {
+        // printf("%d\n", -decoded);
         return -decoded;
     }
     // If Pos
     else
     {
+        // printf("%d\n", decoded);
         return decoded;
     }
 }

--- a/src/encode.c
+++ b/src/encode.c
@@ -6,16 +6,14 @@ SignMag conv_sign_mag(int16_t to_convert)
     uint16_t MAX_MAG = 32635;
     SignMag sign_mag;
 
-    sign_mag.sign = to_convert < 0 ? NEG : POS;                   // Get the sign bit
-    sign_mag.mag = ((to_convert < 0 ? -to_convert : to_convert)); // Grab the rest of the magnitude
+    sign_mag.sign = (to_convert < 0) ? NEG : POS;                 // Get the sign bit
+    sign_mag.mag = ((to_convert < 0) ? -to_convert : to_convert); // Grab the rest of the magnitude
 
-    if (sign_mag.mag < 0)
-        printf("oooopps");
     if (sign_mag.mag > MAX_MAG)
     {
         sign_mag.mag = MAX_MAG;
     }
-    // sign_mag.mag += 132;
+    sign_mag.mag += 132;
 
     return sign_mag;
 }
@@ -24,26 +22,26 @@ SignMag conv_sign_mag(int16_t to_convert)
 char calc_chord(uint16_t magnitude)
 {
     if (magnitude & (1 << 14))
-        return 0x7;
+        return 0x07;
     if (magnitude & (1 << 13))
-        return 0x6;
+        return 0x06;
     if (magnitude & (1 << 12))
-        return 0x5;
+        return 0x05;
     if (magnitude & (1 << 11))
-        return 0x4;
+        return 0x04;
     if (magnitude & (1 << 10))
-        return 0x3;
+        return 0x03;
     if (magnitude & (1 << 9))
-        return 0x2;
+        return 0x02;
     if (magnitude & (1 << 8))
-        return 0x1;
-    return 0;
+        return 0x01;
+    return 0x00;
 }
 
 // Step 3
-char extract_steps(uint16_t input, char chord)
+char extract_steps(uint16_t mag, char chord)
 {
-    return (input >> (chord + 3)) & 0xF;
+    return (mag >> (chord + 3)) & 0x0F;
 }
 
 // Step 4
@@ -66,7 +64,7 @@ char encode(int16_t input)
 {
     SignMag sign_mag = conv_sign_mag(input);
     char chord = calc_chord(sign_mag.mag);
-    char step = extract_steps(input, chord);
+    char step = extract_steps(sign_mag.mag, chord);
     char codeword = assemble_codeword(sign_mag.sign, chord, step);
     return invert_codeword(codeword);
 }

--- a/src/encode.c
+++ b/src/encode.c
@@ -3,17 +3,19 @@
 // Step 1
 SignMag conv_sign_mag(int16_t to_convert)
 {
-    const uint16_t MAX_MAG = 8159;
+    uint16_t MAX_MAG = 32635;
     SignMag sign_mag;
 
-    sign_mag.sign = to_convert < 0 ? NEG : POS;                                 // Get the sign bit
-    sign_mag.mag = ((to_convert < 0 ? ~to_convert : to_convert) >> 2) & 0x1FFF; // Grab the rest of the magnitude
+    sign_mag.sign = to_convert < 0 ? NEG : POS;                   // Get the sign bit
+    sign_mag.mag = ((to_convert < 0 ? -to_convert : to_convert)); // Grab the rest of the magnitude
 
+    if (sign_mag.mag < 0)
+        printf("oooopps");
     if (sign_mag.mag > MAX_MAG)
     {
         sign_mag.mag = MAX_MAG;
     }
-    sign_mag.mag += 33;
+    // sign_mag.mag += 132;
 
     return sign_mag;
 }
@@ -21,19 +23,19 @@ SignMag conv_sign_mag(int16_t to_convert)
 // Step 2
 char calc_chord(uint16_t magnitude)
 {
-    if (magnitude & (1 << 12))
+    if (magnitude & (1 << 14))
         return 0x7;
-    if (magnitude & (1 << 11))
+    if (magnitude & (1 << 13))
         return 0x6;
-    if (magnitude & (1 << 10))
+    if (magnitude & (1 << 12))
         return 0x5;
-    if (magnitude & (1 << 9))
+    if (magnitude & (1 << 11))
         return 0x4;
-    if (magnitude & (1 << 8))
+    if (magnitude & (1 << 10))
         return 0x3;
-    if (magnitude & (1 << 7))
+    if (magnitude & (1 << 9))
         return 0x2;
-    if (magnitude & (1 << 6))
+    if (magnitude & (1 << 8))
         return 0x1;
     return 0;
 }
@@ -41,13 +43,13 @@ char calc_chord(uint16_t magnitude)
 // Step 3
 char extract_steps(uint16_t input, char chord)
 {
-    return (input >> (chord + 1)) & 0xF;
+    return (input >> (chord + 3)) & 0xF;
 }
 
 // Step 4
 char assemble_codeword(Sign sign, char chord, char step)
 {
-    char codeword = ((char)sign ^ 0x1) << 7 | chord << 4 | step;
+    char codeword = ((char)sign ^ 0x01) << 7 | chord << 4 | step;
     return codeword;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,7 @@ int main()
 {
     calc_chord(0x1234);
     printf("yea I do stuff\n");
-    encode_decode_wav("./wow");
+    encode_decode_wav("./guac");
 
     return 0;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -19,7 +19,7 @@ typedef enum Sign
 typedef struct SignMag
 {
     Sign sign;
-    unsigned int mag;
+    uint16_t mag;
 } SignMag;
 
 #endif

--- a/src/wav.c
+++ b/src/wav.c
@@ -102,13 +102,13 @@ void encode_decode_wav(char *filename)
         {
             printf("\ni: ");
             puts_bs16(xfer);
-            printf("\ne: ");
-            puts_bs8(encoded_xfer);
+            // printf("\ne: ");
+            // puts_bs8(encoded_xfer);
             printf("\nd: ");
             puts_bs16(decoded_xfer);
             printf("\n----\n");
-            printf("sizeof xfer: %u\n", sizeof(xfer));
-            printf("sizeof decoded_xfer: %u\n", sizeof(decoded_xfer));
+            // printf("sizeof xfer: %u\n", sizeof(xfer));
+            // printf("sizeof decoded_xfer: %u\n", sizeof(decoded_xfer));
         }
         fwrite(&encoded_xfer, sizeof(encoded_xfer), 1, eofp);
         fwrite(&decoded_xfer, sizeof(decoded_xfer), 1, dofp);

--- a/test/main.c
+++ b/test/main.c
@@ -5,8 +5,10 @@
  */
 int main()
 {
-    test_encode();
-    test_decode();
+    // test_encode();
+    // test_decode();
+    test_conv_sign_mag();
+    test_calc_chord();
     check_summary();
     return 0;
 }

--- a/test/test_encode.c
+++ b/test/test_encode.c
@@ -16,38 +16,38 @@ void test_conv_sign_mag()
 
     check_equal(
         "check conv_sign_mag POS mag",
-        1200 + 33,
-        conv_sign_mag(1200).mag,
+        32635 + 132,
+        conv_sign_mag(32767).mag,
         puts_b16);
 
     check_equal(
         "check conv_sign_mag NEG mag",
-        1200 + 33,
-        conv_sign_mag(-1200).mag,
+        32635 + 132,
+        conv_sign_mag(-32767).mag,
         puts_b16);
 
     check_equal(
         "check conv_sign_mag POS max boundary mag",
-        8159 + 33,
-        conv_sign_mag(8159).mag,
+        32635 + 132,
+        conv_sign_mag(32767).mag,
         puts_b16);
 
     check_equal(
         "check conv_sign_mag NEG max boundary mag",
-        8159 + 33,
-        conv_sign_mag(-8159).mag,
+        32635 + 132,
+        conv_sign_mag(-32767).mag,
         puts_b16);
 
     check_equal(
         "check conv_sign_mag POS max mag",
-        8159 + 33,
-        conv_sign_mag(8200).mag,
+        32635 + 132,
+        conv_sign_mag(32767).mag,
         puts_b16);
 
     check_equal(
         "check conv_sign_mag NEG max mag",
-        8159 + 33,
-        conv_sign_mag(-8200).mag,
+        32635 + 132,
+        conv_sign_mag(-32767).mag,
         puts_b16);
 }
 
@@ -56,102 +56,111 @@ void test_calc_chord()
     check_equal(
         "check calc_chord 0 chord low",
         0,
-        calc_chord(0x0010),
+        calc_chord(0x0080),
         puts_b16);
 
     check_equal(
         "check calc_chord 0 chord boundary",
         0,
-        calc_chord(0x0020),
+        calc_chord(0x0080),
         puts_b16);
 
     check_equal(
         "check calc_chord 0 chord",
         0,
-        calc_chord(0x002F),
+        calc_chord(0x008F),
         puts_b16);
 
     check_equal(
         "check calc_chord 1 chord boundary",
         1,
-        calc_chord(0x0040),
+        calc_chord(0x0100),
         puts_b16);
 
     check_equal(
         "check calc_chord 1 chord",
         1,
-        calc_chord(0x004F),
+        calc_chord(0x010F),
         puts_b16);
 
     check_equal(
         "check calc_chord 2 chord boundary",
         2,
-        calc_chord(0x0080),
+        calc_chord(0x0200),
         puts_b16);
 
     check_equal(
         "check calc_chord 2 chord",
         2,
-        calc_chord(0x008F),
+        calc_chord(0x020F),
         puts_b16);
 
     check_equal(
         "check calc_chord 3 chord boundary",
         3,
-        calc_chord(0x0100),
+        calc_chord(0x0400),
         puts_b16);
 
     check_equal(
         "check calc_chord 3 chord",
         3,
-        calc_chord(0x010F),
+        calc_chord(0x040F),
         puts_b16);
 
     check_equal(
         "check calc_chord 4 chord boundary",
         4,
-        calc_chord(0x0200),
+        calc_chord(0x0800),
         puts_b16);
 
     check_equal(
         "check calc_chord 4 chord",
         4,
-        calc_chord(0x020F),
+        calc_chord(0x080F),
         puts_b16);
 
     check_equal(
         "check calc_chord 5 chord boundary",
         5,
-        calc_chord(0x0400),
+        calc_chord(0x1000),
         puts_b16);
 
     check_equal(
         "check calc_chord 5 chord",
         5,
-        calc_chord(0x040F),
+        calc_chord(0x100F),
         puts_b16);
 
     check_equal(
         "check calc_chord 6 chord boundary",
         6,
-        calc_chord(0x0800),
+        calc_chord(0x2000),
         puts_b16);
 
     check_equal(
         "check calc_chord 6 chord",
         6,
-        calc_chord(0x080F),
+        calc_chord(0x200F),
         puts_b16);
 
     check_equal(
         "check calc_chord 7 chord boundary",
         7,
-        calc_chord(0x1000),
+        calc_chord(0x4000),
         puts_b16);
 
     check_equal(
         "check calc_chord 7 chord",
         7,
+        calc_chord(0x400F),
+        puts_b16);
+}
+
+void test_extract_steps()
+{
+    check_equal(
+        "check extract_steps with chord 1",
+        0b0,
         calc_chord(0x100F),
         puts_b16);
 }

--- a/test/test_encode.c
+++ b/test/test_encode.c
@@ -1,0 +1,157 @@
+#include "test.h"
+
+void test_conv_sign_mag()
+{
+    check_equal(
+        "check conv_sign_mag POS sign",
+        POS,
+        conv_sign_mag(0x1000).sign,
+        puts_b16);
+
+    check_equal(
+        "check conv_sign_mag NEG sign",
+        NEG,
+        conv_sign_mag(0x8000).sign,
+        puts_b16);
+
+    check_equal(
+        "check conv_sign_mag POS mag",
+        1200 + 33,
+        conv_sign_mag(1200).mag,
+        puts_b16);
+
+    check_equal(
+        "check conv_sign_mag NEG mag",
+        1200 + 33,
+        conv_sign_mag(-1200).mag,
+        puts_b16);
+
+    check_equal(
+        "check conv_sign_mag POS max boundary mag",
+        8159 + 33,
+        conv_sign_mag(8159).mag,
+        puts_b16);
+
+    check_equal(
+        "check conv_sign_mag NEG max boundary mag",
+        8159 + 33,
+        conv_sign_mag(-8159).mag,
+        puts_b16);
+
+    check_equal(
+        "check conv_sign_mag POS max mag",
+        8159 + 33,
+        conv_sign_mag(8200).mag,
+        puts_b16);
+
+    check_equal(
+        "check conv_sign_mag NEG max mag",
+        8159 + 33,
+        conv_sign_mag(-8200).mag,
+        puts_b16);
+}
+
+void test_calc_chord()
+{
+    check_equal(
+        "check calc_chord 0 chord low",
+        0,
+        calc_chord(0x0010),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 0 chord boundary",
+        0,
+        calc_chord(0x0020),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 0 chord",
+        0,
+        calc_chord(0x002F),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 1 chord boundary",
+        1,
+        calc_chord(0x0040),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 1 chord",
+        1,
+        calc_chord(0x004F),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 2 chord boundary",
+        2,
+        calc_chord(0x0080),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 2 chord",
+        2,
+        calc_chord(0x008F),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 3 chord boundary",
+        3,
+        calc_chord(0x0100),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 3 chord",
+        3,
+        calc_chord(0x010F),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 4 chord boundary",
+        4,
+        calc_chord(0x0200),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 4 chord",
+        4,
+        calc_chord(0x020F),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 5 chord boundary",
+        5,
+        calc_chord(0x0400),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 5 chord",
+        5,
+        calc_chord(0x040F),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 6 chord boundary",
+        6,
+        calc_chord(0x0800),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 6 chord",
+        6,
+        calc_chord(0x080F),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 7 chord boundary",
+        7,
+        calc_chord(0x1000),
+        puts_b16);
+
+    check_equal(
+        "check calc_chord 7 chord",
+        7,
+        calc_chord(0x100F),
+        puts_b16);
+}


### PR DESCRIPTION
Unstable negative symbols:
<img width="541" alt="Screen Shot 2019-08-03 at 3 35 10 PM" src="https://user-images.githubusercontent.com/11308382/62417703-61031c00-b60b-11e9-94b0-ed61ecaf0890.png">

Fixed by passing absolute value into `extract_step` function. It was trying to extract when the magnitude was still in 2s complement 🤦‍♀ 